### PR TITLE
Glob pattern support

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+  workflow_dispatch:
 
 jobs:
   standard-style:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,6 +5,8 @@ on:
     pull_request:
         branches: [main]
         types: [closed]
+    workflow_dispatch:
+      
 
 jobs:
   unittest:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This GitHub Action performs linting on Ignition `view.json` files to ensure prop
 
 ## Inputs
 
-### `files` (required)
+### `files` (optional)
 
-Space-separated list of paths to the Ignition `view.json` files to be linted.
+Space-separated list of paths or glob patterns to the Ignition `view.json` files to be linted. Glob patterns are supported, e.g., `**/view.json` to match all `view.json` files recursively.
+
+The default value is `**/view.json` to capture all Perspective views.
 
 ### `component_style` (optional)
 

--- a/src/ignition_lint.py
+++ b/src/ignition_lint.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import os
 from checker import StyleChecker
+import glob
 
 
 class JsonLinter:
@@ -105,16 +106,20 @@ class JsonLinter:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--files', default="", help='Space-separated list of ignition files to lint')
+    parser.add_argument('--files', default="**/view.json", help='Space-separated list of ignition files or glob patterns to lint')
     parser.add_argument('--component-style', help='Naming convention style for components')
     parser.add_argument('--parameter-style', help='Naming convention style for parameters')
     parser.add_argument('--component-style-rgx', help='Regex pattern for naming convention style of components')
     parser.add_argument('--parameter-style-rgx', help='Regex pattern for naming convention style of parameters')
     args = parser.parse_args()
 
-    input_files = args.files.split()
+    input_patterns = args.files.split()
+    input_files = []
+    for pattern in input_patterns:
+        input_files.extend(glob.glob(pattern, recursive=True))
+
     if not input_files:
-        print("No files")
+        print("No files found matching the specified patterns")
         sys.exit(0)
 
     linter = JsonLinter(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -62,6 +62,7 @@ class StyleCheckerTests(unittest.TestCase):
         self.assertTrue(checker.is_correct_style("MyVariable123"))
         self.assertTrue(checker.is_correct_style("myVariable123"))                                                 
         self.assertTrue(checker.is_correct_style("MY_VARIABLE_123"))
+    
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ignition_lint.py
+++ b/tests/test_ignition_lint.py
@@ -3,7 +3,7 @@ import os
 import sys
 import os
 from unittest.mock import patch
-from json import JSONDecodeError
+import glob
 
 # Add the src directory to the PYTHONPATH
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
@@ -14,7 +14,8 @@ class JsonLinterTests(unittest.TestCase):
     def setUp(self):
         self.linter = JsonLinter("PascalCase", "camelCase", None, None)
 
-    def evaluate_file_with_valid_json(self, file_path):
+    def test_lint_file_with_valid_json(self):
+        file_path = "./tests/cases/PreferredStyle/view.json"
         expected_errors = {"components": [], "parameters": []}
 
         with patch("builtins.open", create=True) as mock_open:
@@ -28,15 +29,6 @@ class JsonLinterTests(unittest.TestCase):
             mock_file.read.assert_called_once()
             self.assertEqual(lint_errors, 0)
             self.assertEqual(self.linter.errors, expected_errors)
-
-    def test_lint_file_with_valid_json(self):
-        file_path = "./tests/cases/PreferredStyle/view.json"
-        self.evaluate_file_with_valid_json(file_path)
-    
-    def test_glob_pattern_with_single_file(self):
-        file_path = "**/PreferredStyle/view.json"
-        self.evaluate_file_with_valid_json(file_path)
-
 
     def test_lint_file_with_invalid_json(self):
         file_path = "./nonexistent/test/view.json"
@@ -110,6 +102,17 @@ class JsonLinterTests(unittest.TestCase):
         self.linter.check_parameter_names(data, self.linter.errors)
 
         self.assertEqual(self.linter.errors, expected_errors)
+
+    def test_lint_file_with_glob_pattern(self):
+        valid_file_path = "**/PreferredStyle/view.json"
+        invalid_file_path = "nonexistent/**/view.json"
+
+        self.linter.lint_file(valid_file_path)
+        self.assertEqual(self.linter.files_linted, 1)
+
+        self.linter.lint_file(invalid_file_path)
+        self.assertEqual(self.linter.files_linted, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ignition_lint.py
+++ b/tests/test_ignition_lint.py
@@ -14,8 +14,7 @@ class JsonLinterTests(unittest.TestCase):
     def setUp(self):
         self.linter = JsonLinter("PascalCase", "camelCase", None, None)
 
-    def test_lint_file_with_valid_json(self):
-        file_path = "./tests/cases/PreferredStyle/view.json"
+    def evaluate_file_with_valid_json(self, file_path):
         expected_errors = {"components": [], "parameters": []}
 
         with patch("builtins.open", create=True) as mock_open:
@@ -29,6 +28,15 @@ class JsonLinterTests(unittest.TestCase):
             mock_file.read.assert_called_once()
             self.assertEqual(lint_errors, 0)
             self.assertEqual(self.linter.errors, expected_errors)
+
+    def test_lint_file_with_valid_json(self):
+        file_path = "./tests/cases/PreferredStyle/view.json"
+        self.evaluate_file_with_valid_json(file_path)
+    
+    def test_glob_pattern_with_single_file(self):
+        file_path = "**/PreferredStyle/view.json"
+        self.evaluate_file_with_valid_json(file_path)
+
 
     def test_lint_file_with_invalid_json(self):
         file_path = "./nonexistent/test/view.json"


### PR DESCRIPTION
Added support for glob patterns in the view paths.

To test, execute with `**/view.json` so that it captures each view.json in the repository.