### PR TITLE
bugfix: update multi-file test to be comma-separated

### DIFF
--- a/tests/test_ignition_lint.py
+++ b/tests/test_ignition_lint.py
@@ -118,7 +118,7 @@ class JsonLinterTests(unittest.TestCase):
                 []
             }
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with patch("sys.argv", ["ignition_lint.py", "--files"] + [" ".join(file_paths)] + ["--component-style", "PascalCase", "--parameter-style", "PascalCase"]):  # Run ignition_lint.py with the specified file paths as arguments
+            with patch("sys.argv", ["ignition_lint.py", "--files"] + [",".join(file_paths)] + ["--component-style", "PascalCase", "--parameter-style", "PascalCase"]):
                 try:
                     ignition_lint.main()
                 except SystemExit:


### PR DESCRIPTION
* add comma-separated file names to multi-file unit test