### PR TITLE
Fix: Ignore dataset elements

### DIFF
--- a/src/ignition_lint.py
+++ b/src/ignition_lint.py
@@ -78,6 +78,13 @@ class JsonLinter:
 
     def check_parameter_names(self, data, errors: dict, parent_key: str = ""):
         for key, value in data.items():
+            if key in self.keysToSkip:
+                continue
+            
+            # If key has the format of a dataset, skip to next key
+            if key.startswith("$"):
+                continue
+
             if isinstance(value, dict):
                 self.check_parameter_names(value, errors, f"{parent_key}.{key}")
             elif not self.parameter_style_checker.is_correct_style(key) and "props.params" not in parent_key:

--- a/tests/test_ignition_lint.py
+++ b/tests/test_ignition_lint.py
@@ -103,6 +103,68 @@ class JsonLinterTests(unittest.TestCase):
 
         self.assertEqual(self.linter.errors, expected_errors)
 
+    def test_check_parameter_names_with_dataset(self):
+        data = {
+            "$": [
+                "ds",
+                192,
+                1723242356734
+            ],
+            "$columns": [
+                {
+                "name": "City",
+                "type": "String",
+                "data": [
+                    "New York",
+                    "Los Angeles",
+                    "Chicago",
+                    "Houston",
+                    "Phoenix"
+                ]
+                },
+                {
+                "name": "Population",
+                "type": "Integer",
+                "data": [
+                    8363710,
+                    3833995,
+                    2853114,
+                    2242193,
+                    1567924
+                ]
+                },
+                {
+                "name": "Timezone",
+                "type": "String",
+                "data": [
+                    "EST",
+                    "PST",
+                    "CST",
+                    "CST",
+                    "MST"
+                ]
+                },
+                {
+                "name": "GMTOffset",
+                "type": "Integer",
+                "data": [
+                    -5,
+                    -8,
+                    -6,
+                    -6,
+                    -7
+                ]
+                }
+            ]
+        }
+
+        # Should skip the $ key, yielding no errors
+        expected_errors = {"components": [], "parameters": []}
+
+        self.linter.check_parameter_names(data, self.linter.errors)
+
+        self.assertEqual(self.linter.errors, expected_errors)
+
     def test_main_with_multiple_files(self):
         file_paths = ["./tests/cases/camelCase/view.json", "./tests/cases/PascalCase/view.json"]
         expected_errors = {


### PR DESCRIPTION
* If parameter starts with `$`, it should be skipped, as it is a dataset. We aren't checking datasets.