### PR TITLE
Fix: Make files input not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: "Eric Knorr"
 inputs:
   files:
     description: "Comma-separated list of ignition files to lint"
-    required: true
+    required: false
   component_style:
     description: "Naming convention style for components"
     required: false


### PR DESCRIPTION
Set `inputs.files.required` to false, as it already has a default in the action def.