### PR TITLE
Feature: allow css properties in style

### DIFF
--- a/docs/rules-overview.md
+++ b/docs/rules-overview.md
@@ -27,6 +27,7 @@ This document provides a high-level overview of all available linting rules in t
 - Forbidden name patterns
 - Abbreviation handling and validation
 - Node-specific naming patterns
+- **Note**: CSS properties in `style` and `elementStyle` objects are automatically exempted from validation (they remain in kebab-case per CSS spec)
 
 **Configuration options:**
 - `convention`: Predefined patterns (PascalCase, camelCase, snake_case, kebab-case, UPPER_CASE)

--- a/src/ignition_lint/rules/naming/name_pattern.py
+++ b/src/ignition_lint/rules/naming/name_pattern.py
@@ -313,6 +313,28 @@ class NamePatternRule(LintingRule):
 				return None
 		return None
 
+	def _is_css_property(self, node: ViewNode) -> bool:
+		"""
+		Check if a property is a CSS property (in style or elementStyle).
+		CSS properties should always be in kebab-case and should not be validated.
+
+		Args:
+			node: The property node to check
+
+		Returns:
+			True if the property is a CSS property, False otherwise
+		"""
+		if node.node_type != NodeType.PROPERTY:
+			return False
+
+		# Check if the path contains .style. or .elementStyle.
+		# Examples:
+		#   root.root.props.style.touch-action -> CSS property
+		#   root.FlexRepeater.props.elementStyle.flex-direction -> CSS property
+		#   custom.myProperty -> NOT a CSS property
+		path = node.path
+		return '.style.' in path or '.elementStyle.' in path
+
 	def _validate_name(self, node: ViewNode, name: str) -> list:
 		"""
 		Validate a name according to the rules and return a list of error messages.
@@ -395,6 +417,9 @@ class NamePatternRule(LintingRule):
 		self.visit_generic(node)
 
 	def visit_property(self, node: ViewNode):
+		# Skip validation for CSS properties (in style or elementStyle)
+		if self._is_css_property(node):
+			return
 		self.visit_generic(node)
 
 	def visit_event_handler(self, node: ViewNode):

--- a/tests/unit/test_component_naming.py
+++ b/tests/unit/test_component_naming.py
@@ -499,5 +499,143 @@ class TestStandardNamingConventions(BaseRuleTest):
 		)
 
 
+class TestNamePatternCSSProperties(BaseRuleTest):
+	"""Test that CSS properties in style and elementStyle are not flagged as violations."""
+
+	def test_css_properties_in_style_should_pass(self):
+		"""CSS properties in style objects should not be flagged by property naming rules."""
+		rule_config = get_test_config(
+			"NamePatternRule",
+			target_node_types=["property"],
+			convention="camelCase",
+			severity="error"
+		)
+
+		# Create a view with CSS properties in style
+		view_data = {
+			"custom": {},
+			"params": {},
+			"props": {},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"props": {
+					"style": {
+						"touch-action": "none",
+						"background-color": "#ffffff",
+						"font-size": "14px",
+						"z-index": "100"
+					}
+				},
+				"type": "ia.container.coord"
+			}
+		}
+
+		# Write test view file
+		import json
+		import tempfile
+		from pathlib import Path
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+			json.dump(view_data, f)
+			view_file = Path(f.name)
+
+		try:
+			# CSS properties should NOT be flagged as violations
+			self.assert_rule_passes(view_file, rule_config, "NamePatternRule")
+		finally:
+			view_file.unlink()
+
+	def test_css_properties_in_element_style_should_pass(self):
+		"""CSS properties in elementStyle (flex repeater) should not be flagged."""
+		rule_config = get_test_config(
+			"NamePatternRule",
+			target_node_types=["property"],
+			convention="camelCase",
+			severity="error"
+		)
+
+		# Create a view with CSS properties in elementStyle
+		view_data = {
+			"custom": {},
+			"params": {},
+			"props": {},
+			"root": {
+				"children": [
+					{
+						"meta": {
+							"name": "FlexRepeater"
+						},
+						"props": {
+							"elementStyle": {
+								"display": "flex",
+								"flex-direction": "row",
+								"align-items": "center"
+							}
+						},
+						"type": "ia.container.flex"
+					}
+				],
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+
+		# Write test view file
+		import json
+		import tempfile
+		from pathlib import Path
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+			json.dump(view_data, f)
+			view_file = Path(f.name)
+
+		try:
+			# CSS properties should NOT be flagged as violations
+			self.assert_rule_passes(view_file, rule_config, "NamePatternRule")
+		finally:
+			view_file.unlink()
+
+	def test_regular_properties_still_validated(self):
+		"""Regular properties (not in style) should still be validated."""
+		rule_config = get_test_config(
+			"NamePatternRule",
+			target_node_types=["property"],
+			convention="camelCase",
+			severity="error"
+		)
+
+		# Create a view with regular properties that violate camelCase
+		view_data = {
+			"custom": {
+				"BadPropertyName": "value",  # PascalCase - should fail camelCase rule
+				"another-bad-name": "value"  # kebab-case - should fail camelCase rule
+			},
+			"params": {},
+			"props": {},
+			"root": {
+				"meta": {
+					"name": "root"
+				},
+				"type": "ia.container.coord"
+			}
+		}
+
+		# Write test view file
+		import json
+		import tempfile
+		from pathlib import Path
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+			json.dump(view_data, f)
+			view_file = Path(f.name)
+
+		try:
+			# Regular properties SHOULD be flagged as violations
+			self.assert_rule_fails(view_file, rule_config, "NamePatternRule")
+		finally:
+			view_file.unlink()
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## 📖 Description
- Fixes NamePatternRule to allow `kebab-case` in `.style` and `.elementStyle` (CSS properties)

## 🛠 Changes
<!--Please choose one or delete options that are not relevant-->

- [x] Bug fix (change that fixes an issue)
- [ ] Feature (change that adds functionality)
- [ ] Chore (cleanup items not resulting in changes to functionality)

This change is (check all that apply)

- [ ] Breaking (would cause existing functionality not to work as expected)
- [x] Non-breaking
- [ ] Requires documentation update
