### PR TITLE
docs: point users to bw-design-group/ignition-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@
 > **[bw-design-group/ignition-lint](https://github.com/bw-design-group/ignition-lint)**,
 > which is far ahead of this repository and actively maintained.
 >
-> - **pre-commit / CLI users:** point your config at `bw-design-group/ignition-lint`
->   (or `pip install ign-lint`). The `ign-lint` package on PyPI is the maintained line.
+> **Switching is not a 1:1 repoint.** bw's rule-config schema and CLI/Action interface
+> differ from this project's, so you'll need to rework your config (and, for Action
+> users, your workflow) — not just change the reference. There is no formal migration
+> guide (this project saw limited use); follow the current bw README for the config
+> format and supported flags.
+>
+> - **pre-commit / CLI users:** move to `bw-design-group/ignition-lint` (or
+>   `pip install ign-lint`, the maintained PyPI line) and port your config to bw's schema.
 > - **GitHub Action users (`uses: ia-eknorr/ignition-lint@v2.x`):** bw does not ship a
->   GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI call
->   (see the bw README). The `@v2.x` tags here remain resolvable but are frozen.
+>   GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI call,
+>   and move your `component_style`/`parameter_style` inputs into bw's config file. The
+>   `@v2.x` tags here remain resolvable but are frozen.
 >
 > This repository is archived and read-only as of June 2026.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Ignition Lint Documentation
 
+> [!IMPORTANT]
+> **This project has moved.** Active development now happens at
+> **[bw-design-group/ignition-lint](https://github.com/bw-design-group/ignition-lint)**,
+> which is far ahead of this repository and actively maintained.
+>
+> - **pre-commit / CLI users:** point your config at `bw-design-group/ignition-lint`
+>   (or `pip install ign-lint`). The `ign-lint` package on PyPI is the maintained line.
+> - **GitHub Action users (`uses: ia-eknorr/ignition-lint@v2.x`):** bw does not ship a
+>   GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI call
+>   (see the bw README). The `@v2.x` tags here remain resolvable but are frozen.
+>
+> This repository is archived and read-only as of June 2026.
+
 ## Overview
 
 Ignition Lint is a Python framework designed to analyze and lint Ignition Perspective view.json files. It provides a structured way to parse view files, build an object model representation, and apply customizable linting rules to ensure code quality and consistency across your Ignition projects.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # Ignition Lint Documentation
 
 > [!IMPORTANT]
-> **This project has moved.** Active development now happens at
+> **This project has moved.** Active development now happens at Design Group's
 > **[bw-design-group/ignition-lint](https://github.com/bw-design-group/ignition-lint)**,
 > which is far ahead of this repository and actively maintained.
 >
-> **Switching is not a 1:1 repoint.** bw's rule-config schema and CLI/Action interface
-> differ from this project's, so you'll need to rework your config (and, for Action
-> users, your workflow) — not just change the reference. There is no formal migration
-> guide (this project saw limited use); follow the current bw README for the config
-> format and supported flags.
+> **Switching is not a 1:1 repoint.** Design Group's rule-config schema and CLI/Action
+> interface differ from this project's, so you'll need to rework your config (and, for
+> Action users, your workflow) — not just change the reference. There is no formal
+> migration guide (this project saw limited use); follow the current Design Group README
+> for the config format and supported flags.
 >
 > - **pre-commit / CLI users:** move to `bw-design-group/ignition-lint` (or
->   `pip install ign-lint`, the maintained PyPI line) and port your config to bw's schema.
-> - **GitHub Action users (`uses: ia-eknorr/ignition-lint@v2.x`):** bw does not ship a
->   GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI call,
->   and move your `component_style`/`parameter_style` inputs into bw's config file. The
->   `@v2.x` tags here remain resolvable but are frozen.
+>   `pip install ign-lint`, the maintained PyPI line) and port your config to Design
+>   Group's schema.
+> - **GitHub Action users (`uses: ia-eknorr/ignition-lint@v2.x`):** Design Group does not
+>   ship a GitHub Action. Replace the action step with `pip install ign-lint` plus a CLI
+>   call, and move your `component_style`/`parameter_style` inputs into Design Group's
+>   config file. The `@v2.x` tags here remain resolvable but are frozen.
 >
 > This repository is archived and read-only as of June 2026.
 


### PR DESCRIPTION
## Why

`bw-design-group/ignition-lint` (a fork of this repo) is now **229 commits ahead** and is the actively maintained line of the project. This repo's recent history is dependency bumps only. Ahead of archiving this repository, this adds a prominent notice so existing and new users land on the maintained project.

## What

Adds an `> [!IMPORTANT]` banner to the top of the README with version-aware guidance:

- **CLI / pre-commit users** -> `bw-design-group/ignition-lint` (or `pip install ign-lint`, the maintained PyPI line).
- **GitHub Action users** (`uses: ia-eknorr/ignition-lint@v2.x`) -> bw ships no Action, so switch to `pip install ign-lint` + a CLI call. The `@v2.x` tags here stay resolvable but frozen.

No code or behavior changes.